### PR TITLE
Do not extend `ModuleMethods` to class

### DIFF
--- a/lib/abstriker.rb
+++ b/lib/abstriker.rb
@@ -68,8 +68,8 @@ module Abstriker
     base.extend(SyntaxMethods)
     base.singleton_class.extend(SyntaxMethods)
     if enabled?
-      base.extend(ModuleMethods) if base.is_a?(Module)
-      base.extend(ClassMethods) if base.is_a?(Class)
+      base.extend(ModuleMethods) if base.instance_of?(Module)
+      base.extend(ClassMethods) if base.instance_of?(Class)
     end
   end
 


### PR DESCRIPTION
`Class` is a subclass of `Module`, so `.to_a(Module)` returns true when a class is the receiver.

```ruby
c = Class.new
p c.is_a? Module # => true
p c.is_a? Class # => true
```


So class includes `ModuleMethods` module by `Abstriker.extended`.

This change replaces `is_a?` with `instance_of?`. `instance_of?` does not look ancestors, so `SomeClass.instance_of?(Module)` returns false.


```ruby
c = Class.new
p c.instance_of? Module # => false
p c.instance_of? Class # => true
```